### PR TITLE
Fix deployment script warnings

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -3,6 +3,7 @@
 ZIP_PATH="/tmp/libertai-agent.zip"
 CODE_PATH="/root/libertai-agent"
 DOCKERFILE_PATH="/tmp/libertai-agent.Dockerfile"
+CONTAINER_NAME="libertai-agent"
 
 case "$3" in
     fastapi)
@@ -14,29 +15,29 @@ case "$3" in
 esac
 
 # Setup
+export DEBIAN_FRONTEND=noninteractive # Suppress debconf warnings
 apt-get update
 apt-get install unzip -y
 if ! command -v docker &> /dev/null; then
     # Docker installation when not already present
-    curl -fsSL https://get.docker.com | sh
+    curl -fsSL https://get.docker.com | sudo DEBIAN_FRONTEND=noninteractive sh 2>/dev/null
     sudo usermod -aG docker $USER  # Allow non-root usage
-    sudo systemctl enable --now docker  # Start Docker and enable on boot
+    sudo systemctl enable --now docker 2>/dev/null # Start Docker and enable on boot
 fi
 
 
 # Cleaning previous agent
 rm -rf $CODE_PATH
-docker stop libertai-agent
-docker rm libertai-agent
+docker inspect libertai-agent 2>/dev/null && docker stop libertai-agent && docker rm libertai-agent
 
 # Deploying the new agent
 unzip $ZIP_PATH -d $CODE_PATH
 wget https://raw.githubusercontent.com/Libertai/libertai-agents/refs/heads/main/deployment/$2.Dockerfile -O $DOCKERFILE_PATH -q --no-cache
-docker buildx build $CODE_PATH \
+docker buildx build -q $CODE_PATH \
   -f $DOCKERFILE_PATH \
   -t libertai-agent \
   --build-arg PYTHON_VERSION=$1
-docker run --name libertai-agent -p 8000:8000 -d libertai-agent $ENTRYPOINT
+docker run --name $CONTAINER_NAME -p 8000:8000 -d libertai-agent $ENTRYPOINT
 
 # Cleanup
 rm -f $ZIP_PATH


### PR DESCRIPTION
# What does this PR do?

Fixes #37 

Changes the way docker is installed to include buildx and remove the associated deprecation warning.
Also remove debconf interactive warnings.

No warnings are now shown in stderr if everything goes well, allowing for better error handling in the CLI to warn the user only when real errors happen.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/Libertai/libertai-agents/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or [Telegram](https://t.me/libertai)? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
