### PR TITLE
chore: Deployed backend docker image name forced

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -9,7 +9,8 @@ services:
   agents-api:
     build:
       dockerfile: ./Dockerfile
-    container_name: libertai-agents
+    image: libertai-agents-backend
+    container_name: libertai-agents-backend
     restart: unless-stopped
     networks:
       my_ipv6_network:


### PR DESCRIPTION
# What does this PR do?

Set a fixed name for the backend docker image

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/Libertai/libertai-agents/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or [Telegram](https://t.me/libertai)? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?
